### PR TITLE
Update playground to v0.6.3

### DIFF
--- a/openfeature-operator-demo/assets/end-to-end.yaml
+++ b/openfeature-operator-demo/assets/end-to-end.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: open-feature-demo-sa
       containers:
         - name: open-feature-demo
-          image: ghcr.io/open-feature/playground-app:v0.4.0
+          image: ghcr.io/open-feature/playground-app:v0.6.3
           args:
             - flagd
           ports:

--- a/openfeature-operator-demo/assets/scripts/intro_foreground.sh
+++ b/openfeature-operator-demo/assets/scripts/intro_foreground.sh
@@ -1,5 +1,5 @@
 
-DEBUG_VERSION=8
+DEBUG_VERSION=9
 DEMO_APP_PORT=30000
 CERT_MANAGER_VERSION=v1.10.1
 #########################################################


### PR DESCRIPTION
## This PR
- Updates the playground app from v0.4.0 to v0.6.3
- Bumps `DEBUG_VERSION` which is a dummy parameter just to show visually in killercoda UI that the sync between GitHub and killercoda backend worked.

### Related Issues
Closes #17 

### Notes
I have already tested this upgrade on my personal account and can verify the tutorial run-through works after the upgrade.