### PR TITLE
Pin to v0.6.3

### DIFF
--- a/openfeature-demo/assets/scripts/foreground.sh
+++ b/openfeature-demo/assets/scripts/foreground.sh
@@ -1,4 +1,4 @@
-DEBUG_VERSION=9
+DEBUG_VERSION=10
 
 ###############################################
 # Step [1/3]: Install docker compose plugin
@@ -18,8 +18,8 @@ sudo apt install -y docker-compose-plugin  < "/dev/null"
 ###############################################
 git clone https://github.com/open-feature/playground
 cd playground
-sed -i 's#image: jaegertracing/all-in-one:1.38#image: docker.io/jaegertracing/all-in-one:1.38#g' ./docker-compose.yaml
-sed -i 's#image: thomaspoignant/go-feature-flag-relay-proxy:v0.3.0#image: docker.io/thomaspoignant/go-feature-flag-relay-proxy:v0.3.0#g' ./docker-compose.yaml
+git fetch --all --tags
+git checkout tags/v0.6.3
 
 ###############################################
 # Step [3/3]: Start things up!


### PR DESCRIPTION
## This PR
- Pins the demo to v0.6.3 tag
- Means `main` for `open-feature/playground` can again be used for experimental dev work without fear of breaking the tutorial

# Testing / Validation
I have validated this in my playground which has the [same critical code section](https://github.com/agardnerIT/killercoda_tutorials/blob/main/new/assets/scripts/intro_foreground.sh#L16-#L22) as here.

Test it in-browser on the testing ground: `https://killercoda.com/agardnerit/scenario/testing-ground`

Look for the message: `HEAD is now at bff5108 chore(main): release 0.6.3 (#155)`

### Related Issues
- Fixes and closes #22


