### PR TITLE
fix: flagd demo intro script 

### DIFF
--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -32,9 +32,9 @@ services:
             - "3000:3000"
         healthcheck:
             test: ["CMD", "curl", "-sf", "http://0.0.0.0:3000/api/v1/version"]
-            interval: 5s
-            timeout: 30s
-            retries: 5
+            interval: 2s
+            timeout: 120s
+            retries: 10
             start_period: 2s
 
 volumes:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -30,19 +30,5 @@ services:
         ports:
             - "3000:3000"
 
-    flagd:
-        image: ghcr.io/open-feature/flagd:v0.11.5
-        container_name: flagd
-        command: start --port 8013 --uri http://gitea:3000/openfeature/flags/raw/branch/main/example_flags.flagd.json
-        volumes:
-            - flagd-data:/repo
-        networks:
-            - gitea-net
-        depends_on:
-            - server
-        ports:
-            - "8013:8013"   
-
 volumes:
     gitea-data:
-    flagd-data:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -40,6 +40,8 @@ services:
             - gitea-net
         depends_on:
             - server
+        ports:
+            - "8013:8013"   
 
 volumes:
     gitea-data:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -1,6 +1,6 @@
 networks:
-    gitea:
-        external: false
+    gitea-net:
+        driver: bridge
 
 services:
     server:
@@ -8,38 +8,39 @@ services:
         container_name: gitea
         restart: always
         environment:
-        # configuration of the app.ini, the proper GITEA__group__VALUE keyword can be found:
-        # https://docs.gitea.com/administration/config-cheat-sheet
-        # the group is the value in () for no app.ini configuration
+            # configuration of the app.ini, the proper GITEA__group__VALUE keyword can be found:
+            # https://docs.gitea.com/administration/config-cheat-sheet
+            # the group is the value in () for no app.ini configuration
             - USER_UID=1000
             - USER_GID=1000
             - GITEA_DEFAULT__RUN_USER=git
             - GITEA__database__DB_TYPE=sqlite3
-            - GITEA__server__ROOT_URL=http://localhost:3000/
+            - GITEA__server__ROOT_URL=http://0.0.0.0:3000/
             - GITEA__server__START_SSH_SERVER=false
             - GITEA__server__DISABLE_SSH=true
             - GITEA__security__INSTALL_LOCK=true
             - GITEA__repository__ENABLE_PUSH_CREATE_USE=true
             - GITEA__repository__DEFAULT_PUSH_CREATE_PRIVATE=true
-            
+
         networks:
-            - gitea
+            - gitea-net
         volumes:
             - gitea-data:/data
-            - gitea-config:/etc/gitea
+            - gitea-data:/etc/gitea
         ports:
             - "3000:3000"
-            # - "222:22"
 
     flagd:
         image: ghcr.io/open-feature/flagd:v0.11.5
-        # command: sleep infinity
+        container_name: flagd
+        command: start --port 8013 --uri http://gitea:3000/openfeature/flags/raw/branch/main/example_flags.flagd.json
         volumes:
-            - gitea-repo:/repo
+            - flagd-data:/repo
         networks:
-            - gitea
+            - gitea-net
+        depends_on:
+            - server
 
 volumes:
     gitea-data:
-    gitea-config:
-    gitea-repo:
+    flagd-data:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -8,6 +8,9 @@ services:
         container_name: gitea
         restart: always
         environment:
+        # configuration of the app.ini, the proper GITEA__group__VALUE keyword can be found:
+        # https://docs.gitea.com/administration/config-cheat-sheet
+        # the group is the value in () for no app.ini configuration
             - USER_UID=1000
             - USER_GID=1000
             - GITEA_DEFAULT__RUN_USER=git

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -26,9 +26,17 @@ services:
             - gitea-net
         volumes:
             - gitea-data:/data
-            - gitea-data:/etc/gitea
+            # - gitea-data:/etc/gitea
+            - gitea-config:/etc/gitea
         ports:
             - "3000:3000"
+        healthcheck:
+            test: ["CMD", "curl", "-sf", "http://0.0.0.0:3000/api/v1/version"]
+            interval: 5s
+            timeout: 30s
+            retries: 5
+            start_period: 2s
 
 volumes:
     gitea-data:
+    gitea-config:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -10,23 +10,33 @@ services:
         environment:
             - USER_UID=1000
             - USER_GID=1000
-            - GITEA__security__INSTALL_LOCK=true
+            - GITEA_DEFAULT__RUN_USER=git
             - GITEA__database__DB_TYPE=sqlite3
-            - GITEA__server__DOMAIN=localhost
             - GITEA__server__ROOT_URL=http://localhost:3000/
+            - GITEA__server__START_SSH_SERVER=false
+            - GITEA__server__DISABLE_SSH=true
+            - GITEA__security__INSTALL_LOCK=true
+            - GITEA__repository__ENABLE_PUSH_CREATE_USE=true
+            - GITEA__repository__DEFAULT_PUSH_CREATE_PRIVATE=true
+            
         networks:
             - gitea
         volumes:
-            - ./gitea:/data
+            - gitea-data:/data
+            - gitea-config:/etc/gitea
         ports:
             - "3000:3000"
-            - "222:22"
+            # - "222:22"
 
     flagd:
         image: ghcr.io/open-feature/flagd:v0.11.5
-        command: sleep infinity
+        # command: sleep infinity
         volumes:
-            - ./gitea:/repo
+            - gitea-repo:/repo
+        networks:
+            - gitea
 
 volumes:
-    gitea:
+    gitea-data:
+    gitea-config:
+    gitea-repo:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -26,16 +26,7 @@ services:
             - gitea-net
         volumes:
             - gitea-data:/data
-            # - gitea-data:/etc/gitea
-            - gitea-config:/etc/gitea
         ports:
             - "3000:3000"
-        healthcheck:
-            test: ["CMD", "curl", "-sf", "http://0.0.0.0:3000/api/v1/version"]
-            interval: 2s
-            timeout: 30s
-            retries: 5
-
 volumes:
     gitea-data:
-    gitea-config:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -1,0 +1,45 @@
+networks:
+    gitea:
+        external: false
+
+services:
+    db:
+        image: postgres
+        restart: always
+        shm_size: 128mb
+        environment:
+            POSTGRES_USER: gitea
+            POSTGRES_PASSWORD: gitea
+            POSTGRES_DB: gitea
+        networks:
+            - gitea
+        volumes:
+            - gitea-db:/var/lib/postgresql/data
+
+    server:
+        image: docker.gitea.com/gitea:1.23.8
+        container_name: gitea
+        restart: always
+        environment:
+            - USER_UID=1000
+            - USER_GID=1000
+            - GITEA__database__DB_TYPE=postgres
+            - GITEA__database__HOST=db:5432
+            - GITEA__database__NAME=gitea
+            - GITEA__database__USER=gitea
+            - GITEA__database__PASSWD=gitea
+        networks:
+            - gitea
+        volumes:
+            # - ~/gitea.app.ini:/data/gitea/conf/app.ini
+            - gitea:/data
+            - /etc/timezone:/etc/timezone:ro
+            - /etc/localtime:/etc/localtime:ro
+        ports:
+            - "3000:3000"
+            - "222:22"
+        depends_on:
+            - db
+volumes:
+    gitea-db:
+    gitea:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -33,9 +33,8 @@ services:
         healthcheck:
             test: ["CMD", "curl", "-sf", "http://0.0.0.0:3000/api/v1/version"]
             interval: 2s
-            timeout: 120s
-            retries: 10
-            start_period: 2s
+            timeout: 30s
+            retries: 5
 
 volumes:
     gitea-data:

--- a/flagd-demo/assets/docker-compose.yaml
+++ b/flagd-demo/assets/docker-compose.yaml
@@ -3,19 +3,6 @@ networks:
         external: false
 
 services:
-    db:
-        image: postgres
-        restart: always
-        shm_size: 128mb
-        environment:
-            POSTGRES_USER: gitea
-            POSTGRES_PASSWORD: gitea
-            POSTGRES_DB: gitea
-        networks:
-            - gitea
-        volumes:
-            - gitea-db:/var/lib/postgresql/data
-
     server:
         image: docker.gitea.com/gitea:1.23.8
         container_name: gitea
@@ -23,23 +10,23 @@ services:
         environment:
             - USER_UID=1000
             - USER_GID=1000
-            - GITEA__database__DB_TYPE=postgres
-            - GITEA__database__HOST=db:5432
-            - GITEA__database__NAME=gitea
-            - GITEA__database__USER=gitea
-            - GITEA__database__PASSWD=gitea
+            - GITEA__security__INSTALL_LOCK=true
+            - GITEA__database__DB_TYPE=sqlite3
+            - GITEA__server__DOMAIN=localhost
+            - GITEA__server__ROOT_URL=http://localhost:3000/
         networks:
             - gitea
         volumes:
-            # - ~/gitea.app.ini:/data/gitea/conf/app.ini
-            - gitea:/data
-            - /etc/timezone:/etc/timezone:ro
-            - /etc/localtime:/etc/localtime:ro
+            - ./gitea:/data
         ports:
             - "3000:3000"
             - "222:22"
-        depends_on:
-            - db
+
+    flagd:
+        image: ghcr.io/open-feature/flagd:v0.11.5
+        command: sleep infinity
+        volumes:
+            - ./gitea:/repo
+
 volumes:
-    gitea-db:
     gitea:

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -13,7 +13,7 @@ REPO_NAME="flags"
 # Wait for Killercoda to set TRAFFIC_HOST1_3000
 while [[ -z "${TRAFFIC_HOST1_3000:-}" ]]; do
   echo "Waiting for TRAFFIC_HOST1_3000 to be set by Killercoda..."
-  sleep 1
+  sleep 2
 done
 
 if [[ -n "${TRAFFIC_HOST1_3000:-}" ]]; then

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -24,7 +24,13 @@ fi
 echo "Using Gitea URL: $BASE_URL"
 
 echo "Starting Gitea docker container..."
-docker compose -f ~/docker-compose.yaml up -d
+# Killercoda doesn't use the `docker compose` syntax as of now
+if type -P docker-compose &>/dev/null; then
+  docker-compose -f ~/docker-compose.yaml up -d
+else
+  docker compose -f ~/docker-compose.yaml up -d
+fi
+# docker compose -f ~/docker-compose.yaml up -d
 
 # Confirm gitea is functional before making calls
 until curl -s "$BASE_URL:3000/api/v1/version" | grep -q "version"; do

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -60,9 +60,10 @@ ACCESS_TOKEN=$(docker exec -u git gitea gitea admin user generate-access-token \
   --raw > /tmp/output.log
 )
 
-# Wait for Gitea to be available
-# Timeout after 2mins
-timeout 120 bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w ''%{http_code}'' http://0.0.0.0:3000)" != "200" ]]; do sleep 5; done'
+# Download and install 'gitea' CLI: 'tea'
+wget -O tea https://dl.gitea.com/tea/${TEA_CLI_VERSION}/tea-${TEA_CLI_VERSION}-linux-amd64
+chmod +x tea
+mv tea /usr/local/bin
 
 # Authenticate the 'tea' CLI
 tea login add \

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -1,88 +1,76 @@
 #!/bin/bash
 
+set -euo pipefail
+
 DEBUG_VERSION=13
 GITEA_VERSION=1.23.8
 TEA_CLI_VERSION=0.9.2
 FLAGD_VERSION=0.11.5
 
-# Download and install flagd
-wget -O flagd.tar.gz https://github.com/open-feature/flagd/releases/download/flagd%2Fv${FLAGD_VERSION}/flagd_${FLAGD_VERSION}_Linux_x86_64.tar.gz
-tar -xf flagd.tar.gz
-mv flagd_linux_x86_64 flagd
-chmod +x flagd
-mv flagd /usr/local/bin
+# if [[ -n "${TRAFFIC_HOST1_3000:-}" ]]; then
+#   GITEA_URL="https://${TRAFFIC_HOST1_3000}"
+# else
+#   GITEA_URL="http://localhost:3000"
+# fi
 
-rm flagd.tar.gz
-
+echo "Starting Gitea & flagd docker containers..."
 docker compose -f ~/docker-compose.yaml up -d
 
-# Add 'git' user
-adduser \
-  --system \
-  --shell /bin/bash \
-  --gecos 'Git Version Control' \
-  --group \
-  --disabled-password \
-  --home /home/git \
-  git
+# Confirm gitea is functional before making calls
+until docker exec gitea curl -s http://localhost:3000/api/v1/version | tee /tmp/version_output.txt | grep -q "version"; do
+  echo "Gitea not ready yet..."
+  sleep 2
+done
 
-# Configure git for 'ubuntu' and 'git' users
-git config --system user.email "me@faas.com"
-git config --system user.name "OpenFeature"
-
-# Wait for Gitea to be available
-# Timeout after 2mins
-timeout 120 bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w "%{http_code}" http://localhost:3000)" != "200" ]]; do sleep 5; done'
-# timeout 120 bash -c 'until curl -s -o /dev/null -w "%{http_code}" http://0.0.0.0:3000)
-
-# Create a user called 'openfeature'
-# With password 'openfeature'
+# Create a user called 'openfeature' with password 'openfeature'
 # Using the gitea service started with docker
+echo "Creating openfeature admin gitea user..."
 docker exec -u git gitea gitea admin user create \
-   --username=openfeature \
-   --password=openfeature \
-   --email=me@faas.com \
-   --must-change-password=false \
-   -c data/gitea/conf/app.ini
-
-# sudo -u git gitea admin user generate-access-token \
-#   --username=openfeature \
-#   --scopes=repo \
-#   -c=/etc/gitea/app.ini \
-#   --raw > /tmp/output.log
-
-# ACCESS_TOKEN=$(tail -n 1 /tmp/output.log)
-
-ACCESS_TOKEN=$(docker exec -u git gitea gitea admin user generate-access-token \
   --username=openfeature \
-  --scopes=repo \
--c data/gitea/conf/app.ini \
-  --raw > /tmp/output.log
-)
+  --password=openfeature \
+  --email=me@faas.com \
+  --must-change-password=false || echo "User already exits."
+  # -c /etc/gitea
 
-# Download and install 'gitea' CLI: 'tea'
-wget -O tea https://dl.gitea.com/tea/${TEA_CLI_VERSION}/tea-${TEA_CLI_VERSION}-linux-amd64
-chmod +x tea
-mv tea /usr/local/bin
+# Setup access token for tea CLI set up
+echo "Generating gitea access token for tea CLI..."
+docker exec -u git gitea gitea admin user generate-access-token \
+  --username=openfeature \
+  --scopes=all \
+  --raw > /tmp/output.log 
+  # -c /etc/gitea \
+
+ACCESS_TOKEN=$(tail -n 1 /tmp/output.log)
+
+if ! type -P tea &> /dev/null; then 
+  echo "Installing tea CLI..."
+  curl -sL https://dl.gitea.com/tea/${TEA_CLI_VERSION}/tea-${TEA_CLI_VERSION}-linux-amd64 -o /usr/local/bin/tea
+  chmod +x /usr/local/bin/tea
+fi
 
 # Authenticate the 'tea' CLI
 tea login add \
-   --name=openfeature \
-   --user=openfeature \
-   --password=openfeature \
-   --url=http://0.0.0.0:3000 \
-   --token=$ACCESS_TOKEN > /dev/null 2>&1
+  --name local \
+  --url=http://localhost:3000 \
+  --token=$ACCESS_TOKEN > /dev/null 2>&1
 
 # Create an empty repo called 'flags'
 # Clone the template repo
-tea repo create --name=flags --branch=main --init=true > /dev/null 2>&1
-git clone http://openfeature:openfeature@0.0.0.0:3000/openfeature/flags
+tea repo create \
+  --name=flags \
+  --branch=main \
+  --init=true >/dev/null
+
+git clone http://openfeature:openfeature@localhost:3000/openfeature/flags
+
 wget -O ~/flags/example_flags.flagd.json https://raw.githubusercontent.com/open-feature/flagd/refs/tags/flagd/v${FLAGD_VERSION}/samples/example_flags.flagd.json
-cd ~/flags
+
 git config credential.helper cache
+
+cd ~/flags
 git add -A
-git commit -m "add flags"
-git push
+git commit -m "seed flags from flagd json"
+git push origin main
 
 # ---------------------------------------------#
 #       🎉 Installation Complete 🎉           #

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -1,23 +1,27 @@
 #!/bin/bash
 
-set -euo pipefail
-
 DEBUG_VERSION=13
 GITEA_VERSION=1.23.8
 TEA_CLI_VERSION=0.9.2
 FLAGD_VERSION=0.11.5
 
-# if [[ -n "${TRAFFIC_HOST1_3000:-}" ]]; then
-#   GITEA_URL="https://${TRAFFIC_HOST1_3000}"
-# else
-#   GITEA_URL="http://localhost:3000"
-# fi
+if [[ -n "${TRAFFIC_HOST1_3000:-}" ]]; then
+  GITEA_URL="http://${TRAFFIC_HOST1_3000}"
+elif [[ -n "${GITEA_URL:-}" ]]; then
+  # Use passed-in GITEA_URL environment variable (e.g. host.docker.internal on Mac/Windows)
+  GITEA_URL="${GITEA_URL}"
+else
+  # Fallback default
+  GITEA_URL="http://gitea:3000"
+fi
+
+echo "Using Gitea URL: $GITEA_URL"
 
 echo "Starting Gitea & flagd docker containers..."
 docker compose -f ~/docker-compose.yaml up -d
 
 # Confirm gitea is functional before making calls
-until docker exec gitea curl -s http://localhost:3000/api/v1/version | grep -q "version"; do
+until docker exec gitea curl -s "$GITEA_URL/api/v1/version" | grep -q "version"; do
   echo "Gitea not ready yet..."
   sleep 2
 done
@@ -34,14 +38,13 @@ if ! echo "$user_list" | grep -qw "openfeature"; then
     --password=openfeature \
     --email=me@faas.com \
     --must-change-password=false
-    # -c /etc/gitea
 else
   echo "User already exists. Continuing..."
 fi
 
 echo "Checking for existing token ..."
 user_tokens=$(docker exec gitea curl -s -H "Authorization: Basic $(echo -n "openfeature:openfeature" | base64)" \
-  http://localhost:3000/api/v1/users/openfeature/tokens)
+  "$GITEA_URL/api/v1/users/openfeature/tokens")
 
 # Output the token check into JSON array & looping to get id of tea_token
 token_id=$(echo "$user_tokens" | jq -r '.[] | select(.name == "tea_token") | .id') > /dev/null
@@ -51,7 +54,7 @@ token_id=$(echo "$user_tokens" | jq -r '.[] | select(.name == "tea_token") | .id
 if [ -n "$token_id" ] && [ "$token_id" != "null" ]; then
   echo "Deleting existing token..."
   docker exec gitea curl -s -X DELETE \
-    http://localhost:3000/api/v1/users/openfeature/tokens/$token_id \
+    "$GITEA_URL/api/v1/users/openfeature/tokens/$token_id" \
     -H "Authorization: Basic $(echo -n "openfeature:openfeature" | base64)"
   echo "Re-generating gitea access token for tea CLI..."
 else
@@ -65,39 +68,60 @@ docker exec -u git gitea gitea admin user generate-access-token \
   --token-name=tea_token \
   --scopes=all \
   --raw > /tmp/output.log 
-  # -c /etc/gitea \
 
 ACCESS_TOKEN=$(tail -n 1 /tmp/output.log)
 
 if ! type -P tea &> /dev/null; then 
   echo "Installing tea CLI..."
-  curl -sL https://dl.gitea.com/tea/${TEA_CLI_VERSION}/tea-${TEA_CLI_VERSION}-linux-amd64 -o /usr/local/bin/tea
-  chmod +x /usr/local/bin/tea
+  # Download and install 'gitea' CLI: 'tea'
+  wget -O tea https://dl.gitea.com/tea/${TEA_CLI_VERSION}/tea-${TEA_CLI_VERSION}-linux-amd64
+  chmod +x tea
+  mv tea /usr/local/bin
 fi
 
 # Authenticate the 'tea' CLI
+echo "Authenticate tea CLI..."
 tea login add \
-  --name local \
-  --url=http://localhost:3000 \
-  --token=$ACCESS_TOKEN > /dev/null 2>&1
+  --name=local \
+  --url="$GITEA_URL" \
+  --token="$ACCESS_TOKEN" # > /dev/null 2>&1
 
-# Create an empty repo called 'flags'
-# Clone the template repo
-tea repo create \
-  --name=flags \
-  --branch=main \
-  --init=true >/dev/null
+# Check if repo 'flags' exists
+echo "Checking if repo 'flags' exists..."
+repo_exists=$(tea repo list --json | jq -e '.[] | select(.name=="flags")' >/dev/null 2>&1 && echo "yes" || echo "no")
 
-git clone http://openfeature:openfeature@localhost:3000/openfeature/flags
+if [[ "$repo_exists" == "yes" ]]; then
+  echo "Repo 'flags' already exists. Skipping creation."
+else
+  echo "Creating repo 'flags'..."
+  tea repo create --login=local --name=flags --branch=main --init=true >/dev/null
+fi
 
-wget -O ~/flags/example_flags.flagd.json https://raw.githubusercontent.com/open-feature/flagd/refs/tags/flagd/v${FLAGD_VERSION}/samples/example_flags.flagd.json
+# Add 'git' user
+adduser \
+  --system \
+  --shell /bin/bash \
+  --gecos 'Git Version Control' \
+  --group \
+  --disabled-password \
+  --home /home/git \
+  git
+
+# Configure git for 'ubuntu' and 'git' users
+git config --system user.email "me@faas.com"
+git config --system user.name "OpenFeature"
+
+git clone http://openfeature:openfeature@${GITEA_URL#http://}/openfeature/flags
+
+cd flags
+wget -O example_flags.flagd.json https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json
 
 git config credential.helper cache
-
-cd ~/flags
 git add -A
 git commit -m "seed flags from flagd json"
 git push origin main
+
+echo  🎉 Installation Complete 🎉 Please proceed now...   
 
 # ---------------------------------------------#
 #       🎉 Installation Complete 🎉           #

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -4,6 +4,11 @@ DEBUG_VERSION=13
 GITEA_VERSION=1.23.8
 TEA_CLI_VERSION=0.9.2
 FLAGD_VERSION=0.11.5
+USER_NAME="openfeature"
+PASSWORD="openfeature"
+USER_EMAIL=me@faas.com
+TOKEN_NAME="tea_token"
+REPO_NAME="flags"
 
 if [[ -n "${TRAFFIC_HOST1_3000:-}" ]]; then
   BASE_URL="http://${TRAFFIC_HOST1_3000}"
@@ -31,32 +36,32 @@ done
 user_list=$(docker exec -u git gitea gitea admin user list 2>/dev/null)
 
 # Check if openfeature user exists
-if ! echo "$user_list" | grep -qw "openfeature"; then
+if ! echo "$user_list" | grep -qw "$USER_NAME"; then
   # Using the gitea service started with docker
   echo "Creating openfeature admin gitea user..."
   docker exec -u git gitea gitea admin user create \
-    --username=openfeature \
-    --password=openfeature \
-    --email=me@faas.com \
+    --username=$USER_NAME \
+    --password=$PASSWORD \
+    --email=$USER_EMAIL \
     --must-change-password=false
 else
   echo "User already exists. Continuing..."
 fi
 
 echo "Checking for existing token ..."
-user_tokens=$(docker exec gitea curl -s -H "Authorization: Basic $(echo -n "openfeature:openfeature" | base64)" \
-  "$GITEA_URL/api/v1/users/openfeature/tokens")
+user_tokens=$(docker exec gitea curl -s -H "Authorization: Basic $(echo -n "$USER_NAME:$USER_PASSWORD" | base64)" \
+  "$BASE_URL/api/v1/users/$USER_NAME/tokens")
 
 # Output the token check into JSON array & looping to get id of tea_token
-token_id=$(echo "$user_tokens" | jq -r '.[] | select(.name == "tea_token") | .id') > /dev/null
+token_id=$(echo "$user_tokens" | jq -r '.[] | select(.name == $TOKEN_NAME) | .id') > /dev/null
 
 # When the token ID exists delete to regenerate to adhere to gitea usage
 # non-empty && not null
 if [ -n "$token_id" ] && [ "$token_id" != "null" ]; then
   echo "Deleting existing token..."
   docker exec gitea curl -s -X DELETE \
-    "$GITEA_URL/api/v1/users/openfeature/tokens/$token_id" \
-    -H "Authorization: Basic $(echo -n "openfeature:openfeature" | base64)"
+    "$BASE_URL/api/v1/users/$USER_NAME/tokens/$token_id" \
+    -H "Authorization: Basic $(echo -n "$USER_NAME:$USER_PASSWORD" | base64)"
   echo "Re-generating gitea access token for tea CLI..."
 else
   echo "No existing tea_token."
@@ -65,8 +70,8 @@ fi
 
 # Generate access token for tea CLI set up
 docker exec -u git gitea gitea admin user generate-access-token \
-  --username=openfeature \
-  --token-name=tea_token \
+  --username=$USER_NAME \
+  --token-name=$TOKEN_NAME \
   --scopes=all \
   --raw > /tmp/output.log 
 
@@ -89,13 +94,13 @@ tea login add \
 
 # Check if repo 'flags' exists
 echo "Checking if repo 'flags' exists..."
-repo_exists=$(tea repo list --json | jq -e '.[] | select(.name=="flags")' >/dev/null 2>&1 && echo "yes" || echo "no")
+repo_exists=$(tea repo list --json | jq -e '.[] | select(.name==$REPO_NAME)' >/dev/null 2>&1 && echo "yes" || echo "no")
 
 if [[ "$repo_exists" == "yes" ]]; then
   echo "Repo 'flags' already exists. Skipping creation."
 else
   echo "Creating repo 'flags'..."
-  tea repo create --login=local --name=flags --branch=main --init=true >/dev/null
+  tea repo create --login=local --name=$REPO_NAME --branch=main --init=true >/dev/null
 fi
 
 # Add 'git' user
@@ -109,12 +114,12 @@ adduser \
   git
 
 # Configure git for 'ubuntu' and 'git' users
-git config --system user.email "me@faas.com"
-git config --system user.name "OpenFeature"
+git config --system user.email $USER_EMAIL
+git config --system user.name $USER_NAME
 
-git clone http://openfeature:openfeature@${BASE_URL#http://}:3000/openfeature/flags
+git clone http://$USER_NAME:$USER_PASSWORD@${BASE_URL#http://}:3000/$USER_NAME/flags
 
-cd flags
+cd $REPO_NAME
 wget -O example_flags.flagd.json https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json
 
 git config credential.helper cache

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+# set -euo pipefail
 
 DEBUG_VERSION=13
 GITEA_VERSION=1.23.8

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -10,6 +10,12 @@ USER_EMAIL=me@faas.com
 TOKEN_NAME="tea_token"
 REPO_NAME="flags"
 
+# Wait for Killercoda to set TRAFFIC_HOST1_3000
+while [[ -z "${TRAFFIC_HOST1_3000:-}" ]]; do
+  echo "Waiting for TRAFFIC_HOST1_3000 to be set by Killercoda..."
+  sleep 1
+done
+
 if [[ -n "${TRAFFIC_HOST1_3000:-}" ]]; then
   BASE_URL="http://${TRAFFIC_HOST1_3000}"
 elif [[ -n "${BASE_URL:-}" ]]; then

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -25,7 +25,7 @@ if [[ -n "${BASE_URL:-}" ]]; then
   # Makes it easier to run locally with mock killercoda env dockerfile
   BASE_URL="${BASE_URL}"
 else
-  BASE_URL="http://${TRAFFIC_HOST1_3000}"
+  BASE_URL="http://${TRAFFIC_HOST1_3000:-0.0.0.0:3000}"
   # Fallback default
   # BASE_URL="http://localhost:3000"
   # BASE_URL="http://${TRAFFIC_HOST1_3000}"

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -26,15 +26,15 @@ until [ "$(docker inspect --format='{{.State.Health.Status}}' gitea)" == "health
   sleep 5
 done
 
-if [[ -n "${TRAFFIC_HOST1_3000:-}" ]]; then
-  BASE_URL="http://${TRAFFIC_HOST1_3000}"
-elif [[ -n "${BASE_URL:-}" ]]; then
-  # Use passed-in BASE_URL environment variable (e.g. host.docker.internal on Mac/Windows)
+if [[ -n "${BASE_URL:-}" ]]; then
+  # Use passed-in BASE_URL environment variable (e.g. host.docker.internal:3000 on Mac/Windows)
   # Makes it easier to run locally with mock killercoda env dockerfile
-  BASE_URL="${BASE_URL}:3000"
+  BASE_URL="${BASE_URL}"
+elif [[ -n "${TRAFFIC_HOST1_3000:-}" ]]; then
+  BASE_URL="http://${TRAFFIC_HOST1_3000}"
 else
   # Fallback default
-  BASE_URL="http://localhost"
+  BASE_URL="http://localhost:3000"
 fi
 
 echo "Using base URL: $BASE_URL"

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -11,14 +11,14 @@ TOKEN_NAME="tea_token"
 REPO_NAME="flags"
 
 echo "Checking if docker-compose.yaml exists at /root:"
-ls -l /docker-compose.yaml || echo "docker-compose.yaml not found!"
+ls -l ~/docker-compose.yaml || echo "docker-compose.yaml not found!"
 
 echo "Starting Gitea docker container..."
 # Killercoda doesn't use the `docker compose` syntax as of now
 if type -P docker-compose &>/dev/null; then
-  docker-compose -f /docker-compose.yaml up -d
+  docker-compose -f ~/docker-compose.yaml up -d
 else
-  docker compose -f /docker-compose.yaml up -d
+  docker compose -f ~/docker-compose.yaml up -d
 fi
 
 echo "Waiting for Gitea container to be healthy..."

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -138,7 +138,7 @@ adduser \
 git config --system user.email $USER_EMAIL
 git config --system user.name $USER_NAME
 
-git clone http://$USER_NAME:$USER_PASSWORD@${BASE_URL#http://}/$USER_NAME/$REPO_NAME
+git clone http://$USER_NAME:$USER_PASSWORD@${BASE_URL#http://}/$USER_NAME/$REPO_NAME /$REPO_NAME
 
 wget -P /$REPO_NAME https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json
 cd /$REPO_NAME

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -60,7 +60,7 @@ user_tokens=$(docker exec gitea curl -s -H "Authorization: Basic $(echo -n "$USE
   "$BASE_URL/api/v1/users/$USER_NAME/tokens")
 
 # Output the token check into JSON array & looping to get id of tea_token
-token_id=$(echo "$user_tokens" | jq -r '.[] | select(.name == $TOKEN_NAME) | .id') > /dev/null
+token_id=$(echo "$user_tokens" | jq -er --arg TOKEN_NAME "$TOKEN_NAME" '.[] | select(.name == $TOKEN_NAME) | .id') > /dev/null
 
 # When the token ID exists delete to regenerate to adhere to gitea usage
 # non-empty && not null
@@ -102,7 +102,7 @@ tea login add \
 
 # Check if repo 'flags' exists
 echo "Checking if repo 'flags' exists..."
-repo_exists=$(tea repo list --json | jq -e '.[] | select(.name==$REPO_NAME)' >/dev/null 2>&1 && echo "yes" || echo "no")
+repo_exists=$(tea repo list --json | jq -er --arg REPO_NAME "$REPO_NAME" '.[] | select(.name==$REPO_NAME)' >/dev/null 2>&1 && echo "yes" || echo "no")
 
 if [[ "$repo_exists" == "yes" ]]; then
   echo "Repo 'flags' already exists. Skipping creation."

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -12,42 +12,9 @@ mv flagd_linux_x86_64 flagd
 chmod +x flagd
 mv flagd /usr/local/bin
 
-# Download and install 'gitea' CLI: 'tea'
-wget -O tea https://dl.gitea.com/tea/${TEA_CLI_VERSION}/tea-${TEA_CLI_VERSION}-linux-amd64
-chmod +x tea
-mv tea /usr/local/bin
+rm flagd.tar.gz
 
-mkdir -p /tmp/gpg-temp
-chmod 700 /tmp/gpg-temp
-
-# Download 'gitea'
-wget -O gitea https://dl.gitea.com/gitea/${GITEA_VERSION}/gitea-${GITEA_VERSION}-linux-amd64
-chmod +x gitea
-
-wget -O gitea-${GITEA_VERSION}-linux-amd64.asc https://dl.gitea.com/gitea/${GITEA_VERSION}/gitea-${GITEA_VERSION}-linux-amd64.asc
-
-gpg --homedir /tmp/gpg-temp --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
-gpg --homedir /tmp/gpg-temp --verify gitea-${GITEA_VERSION}-linux-amd64.asc gitea
-
-mv gitea /usr/local/bin
-
-rm -rf /tmp/gpg-temp
-
-#################
-# Install postgresql for Gitea
-###################
-# Create the file repository configuration:
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-
-# Import the repository signing key:
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-
-# Update the package lists:
-sudo apt-get update
-
-# Install the latest version of PostgreSQL.
-# If you want a specific version, use 'postgresql-12' or similar instead of 'postgresql':
-sudo apt-get -y install postgresql < /dev/null
+docker compose -f ~/docker-compose.yaml up -d
 
 # Add 'git' user
 adduser \
@@ -63,95 +30,35 @@ adduser \
 git config --system user.email "me@faas.com"
 git config --system user.name "OpenFeature"
 
-# Download 'gitea'
-wget -O gitea https://dl.gitea.com/gitea/${GITEA_VERSION}/gitea-${GITEA_VERSION}-linux-amd64
-chmod +x gitea
-mv gitea /usr/local/bin
-chown git:git /usr/local/bin/gitea
-
-# Set up directory structure for 'gitea'
-mkdir -p /var/lib/gitea/{custom,data,log}
-chown -R git:git /var/lib/gitea/
-chmod -R 750 /var/lib/gitea/
-mkdir /etc/gitea
-chown git:git /etc/gitea
-chmod 770 /etc/gitea
-
-# Create systemd service for 'gitea'
-# Ref: https://github.com/go-gitea/gitea/blob/main/contrib/systemd/gitea.service
-mv ~/gitea.service /etc/systemd/system/gitea.service
-# cat <<EOF > /etc/systemd/system/gitea.service
-# [Unit]
-# Description=Gitea (Git with a cup of tea)
-# After=syslog.target
-# After=network.target
-
-# Wants=postgresql.service
-# After=postgresql.service
-
-# [Service]
-# RestartSec=2s
-# Type=simple
-# User=git
-# Group=git
-# WorkingDirectory=/var/lib/gitea/
-# ExecStart=/usr/local/bin/gitea web --config /etc/gitea/app.ini
-# Restart=always
-# Environment=USER=git HOME=/home/git GITEA_WORK_DIR=/var/lib/gitea
-
-# [Install]
-# WantedBy=multi-user.target
-# EOF
-
-mv ~/gitea.app.ini /etc/gitea/app.ini
-# cat <<EOF > /etc/gitea/app.ini
-# APP_NAME = "Gitea: Git with a cup of tea"
-# RUN_USER = "git"
-# [server]
-# PROTOCOL = "http"
-# DOMAIN = "http://0.0.0.0:3000"
-# ROOT_URL = "http://0.0.0.0:3000"
-# HTTP_ADDR = "0.0.0.0"
-# HTTP_PORT = "3000"
-# [database]
-# DB_TYPE = "postgres"
-# HOST = "0.0.0.0:5432"
-# NAME = "giteadb"
-# USER = "gitea"
-# PASSWD = "gitea"
-# [repository]
-# ENABLE_PUSH_CREATE_USER = true
-# DEFAULT_PUSH_CREATE_PRIVATE = false
-# [security]
-# INSTALL_LOCK = true
-# EOF
-chown -R git:git /etc/gitea
-
-# Set up gitea DB
-sudo -u postgres -H -- psql --command "CREATE ROLE gitea WITH LOGIN PASSWORD 'gitea';" > /dev/null 2>&1
-sudo -u postgres -H -- psql --command "CREATE DATABASE giteadb WITH OWNER gitea TEMPLATE template0 ENCODING UTF8 LC_COLLATE 'en_US.UTF-8' LC_CTYPE 'en_US.UTF-8';" > /dev/null 2>&1
-
-# Start gitea
-systemctl start gitea
-# Migrate the DB to create all required tables and config
-sudo -u git gitea migrate -c=/etc/gitea/app.ini 
+# Wait for Gitea to be available
+# Timeout after 2mins
+timeout 120 bash -c 'while [[ "$(curl --insecure -s -o /dev/null -w "%{http_code}" http://localhost:3000)" != "200" ]]; do sleep 5; done'
+# timeout 120 bash -c 'until curl -s -o /dev/null -w "%{http_code}" http://0.0.0.0:3000)
 
 # Create a user called 'openfeature'
 # With password 'openfeature'
-sudo -u git gitea admin user create \
+# Using the gitea service started with docker
+docker exec -u git gitea gitea admin user create \
    --username=openfeature \
    --password=openfeature \
    --email=me@faas.com \
    --must-change-password=false \
-   -c=/etc/gitea/app.ini
+   -c data/gitea/conf/app.ini
 
-sudo -u git gitea admin user generate-access-token \
+# sudo -u git gitea admin user generate-access-token \
+#   --username=openfeature \
+#   --scopes=repo \
+#   -c=/etc/gitea/app.ini \
+#   --raw > /tmp/output.log
+
+# ACCESS_TOKEN=$(tail -n 1 /tmp/output.log)
+
+ACCESS_TOKEN=$(docker exec -u git gitea gitea admin user generate-access-token \
   --username=openfeature \
   --scopes=repo \
-  -c=/etc/gitea/app.ini \
+-c data/gitea/conf/app.ini \
   --raw > /tmp/output.log
-
-ACCESS_TOKEN=$(tail -n 1 /tmp/output.log)
+)
 
 # Wait for Gitea to be available
 # Timeout after 2mins

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -10,13 +10,16 @@ USER_EMAIL=me@faas.com
 TOKEN_NAME="tea_token"
 REPO_NAME="flags"
 
+echo "Checking if docker-compose.yaml exists at /root:"
+ls -l /root/docker-compose.yaml || echo "docker-compose.yaml not found!"
+
 
 echo "Starting Gitea docker container..."
 # Killercoda doesn't use the `docker compose` syntax as of now
 if type -P docker-compose &>/dev/null; then
-  docker-compose -f ~/docker-compose.yaml up -d
+  docker-compose -f /root/docker-compose.yaml up -d
 else
-  docker compose -f ~/docker-compose.yaml up -d
+  docker compose -f /root/docker-compose.yaml up -d
 fi
 
 echo "Waiting for Gitea container to be healthy..."

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -22,15 +22,20 @@ until docker exec gitea curl -s http://localhost:3000/api/v1/version | tee /tmp/
   sleep 2
 done
 
-# Create a user called 'openfeature' with password 'openfeature'
-# Using the gitea service started with docker
-echo "Creating openfeature admin gitea user..."
-docker exec -u git gitea gitea admin user create \
-  --username=openfeature \
-  --password=openfeature \
-  --email=me@faas.com \
-  --must-change-password=false || echo "User already exits."
-  # -c /etc/gitea
+# Check if openfeature user exists
+user_list=$(docker exec -u git gitea gitea admin user list 2>/dev/null)
+
+if ! echo "$user_list" | grep -qw "openfeature"; then
+  # Create a user called 'openfeature' with password 'openfeature'
+  # Using the gitea service started with docker
+  echo "Creating openfeature admin gitea user..."
+  docker exec -u git gitea gitea admin user create \
+    --username=openfeature \
+    --password=openfeature \
+    --email=me@faas.com \
+    --must-change-password=false
+    # -c /etc/gitea
+fi
 
 # Setup access token for tea CLI set up
 echo "Generating gitea access token for tea CLI..."

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -138,10 +138,10 @@ adduser \
 git config --system user.email $USER_EMAIL
 git config --system user.name $USER_NAME
 
-git clone http://$USER_NAME:$USER_PASSWORD@${BASE_URL#http://}/$USER_NAME/$REPO_NAME /$REPO_NAME
+git clone http://$USER_NAME:$USER_PASSWORD@${BASE_URL#http://}/$USER_NAME/$REPO_NAME ~/$REPO_NAME
 
-wget -P /$REPO_NAME https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json
-cd /$REPO_NAME
+wget -P ~/$REPO_NAME https://raw.githubusercontent.com/open-feature/flagd/main/samples/example_flags.flagd.json
+cd ~/$REPO_NAME
 
 git config credential.helper cache
 git add -A

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DEBUG_VERSION=13
-GITEA_VERSION=1.19
+GITEA_VERSION=1.23.8
 TEA_CLI_VERSION=0.9.2
 FLAGD_VERSION=0.11.5
 
@@ -16,6 +16,22 @@ mv flagd /usr/local/bin
 wget -O tea https://dl.gitea.com/tea/${TEA_CLI_VERSION}/tea-${TEA_CLI_VERSION}-linux-amd64
 chmod +x tea
 mv tea /usr/local/bin
+
+mkdir -p /tmp/gpg-temp
+chmod 700 /tmp/gpg-temp
+
+# Download 'gitea'
+wget -O gitea https://dl.gitea.com/gitea/${GITEA_VERSION}/gitea-${GITEA_VERSION}-linux-amd64
+chmod +x gitea
+
+wget -O gitea-${GITEA_VERSION}-linux-amd64.asc https://dl.gitea.com/gitea/${GITEA_VERSION}/gitea-${GITEA_VERSION}-linux-amd64.asc
+
+gpg --homedir /tmp/gpg-temp --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
+gpg --homedir /tmp/gpg-temp --verify gitea-${GITEA_VERSION}-linux-amd64.asc gitea
+
+mv gitea /usr/local/bin
+
+rm -rf /tmp/gpg-temp
 
 #################
 # Install postgresql for Gitea

--- a/flagd-demo/assets/scripts/intro_foreground.sh
+++ b/flagd-demo/assets/scripts/intro_foreground.sh
@@ -11,15 +11,14 @@ TOKEN_NAME="tea_token"
 REPO_NAME="flags"
 
 echo "Checking if docker-compose.yaml exists at /root:"
-ls -l /root/docker-compose.yaml || echo "docker-compose.yaml not found!"
-
+ls -l /docker-compose.yaml || echo "docker-compose.yaml not found!"
 
 echo "Starting Gitea docker container..."
 # Killercoda doesn't use the `docker compose` syntax as of now
 if type -P docker-compose &>/dev/null; then
-  docker-compose -f /root/docker-compose.yaml up -d
+  docker-compose -f /docker-compose.yaml up -d
 else
-  docker compose -f /root/docker-compose.yaml up -d
+  docker compose -f /docker-compose.yaml up -d
 fi
 
 echo "Waiting for Gitea container to be healthy..."

--- a/flagd-demo/dockerfile
+++ b/flagd-demo/dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:noble
+
+RUN apt-get update \
+&& DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y wget git vim sudo ca-certificates curl gnupg lsb-release coreutils jq \
+&& rm -rf /var/lib/apt/lists/*
+
+# Install docker in docker to mock killercoda's ability to use docker
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+    https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce-cli docker-compose-plugin
+
+# Add the necessary files needed to run
+COPY assets/scripts/intro_foreground.sh /usr/local/bin/intro_foreground.sh
+COPY assets/docker-compose.yaml /root/docker-compose.yaml
+
+# Add executable permission
+RUN chmod +x /usr/local/bin/intro_foreground.sh
+
+# Run the script file
+# CMD ["/usr/local/bin/intro_foreground.sh"]

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -46,8 +46,8 @@
     "assets": {
       "host01": [
         { 
-          "file": "assets/docker-compose.yaml",
-          "target": "/docker-compose.yaml"
+          "file": "docker-compose.yaml",
+          "target": "~"
         }
       ]
     }

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -47,7 +47,7 @@
       "host01": [
         {
           "file": "docker-compose.yaml",
-          "target": "/root/docker-compose.yaml"
+          "target": "~/docker-compose.yaml"
         }
       ]
     }
@@ -59,6 +59,10 @@
     "ports": [
       {
         "port": 3000,
+        "on": "host01"
+      },
+            {
+        "port": 8013,
         "on": "host01"
       }
     ]

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -45,8 +45,8 @@
     },
     "assets": {
       "host01": [
-        {
-          "file": "docker-compose.yaml",
+        { 
+          "file": "assets/docker-compose.yaml",
           "target": "~/docker-compose.yaml"
         }
       ]

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -46,7 +46,7 @@
     "assets": {
       "host01": [
         { 
-          "file": "assets/docker-compose.yaml",
+          "file": "flagd-demo/assets/docker-compose.yaml",
           "target": "~/docker-compose.yaml"
         }
       ]

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -54,6 +54,10 @@
           "file": "gitea.service",
           "chmod": "+x",
           "target": "~"
+        },
+        {
+          "file": "docker-compose.yaml",
+          "target": "~"
         }
       ]
     }

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -46,16 +46,6 @@
     "assets": {
       "host01": [
         {
-          "file": "gitea.app.ini",
-          "chmod": "+x",
-          "target": "~"
-        },
-        {
-          "file": "gitea.service",
-          "chmod": "+x",
-          "target": "~"
-        },
-        {
           "file": "docker-compose.yaml",
           "target": "/root/docker-compose.yaml"
         }

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -47,7 +47,7 @@
       "host01": [
         { 
           "file": "docker-compose.yaml",
-          "target": "~"
+          "target": "~/"
         }
       ]
     }

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -46,8 +46,8 @@
     "assets": {
       "host01": [
         { 
-          "file": "flagd-demo/assets/docker-compose.yaml",
-          "target": "~/docker-compose.yaml"
+          "file": "assets/docker-compose.yaml",
+          "target": "/root/docker-compose.yaml"
         }
       ]
     }

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -55,7 +55,13 @@
   "environment": {
     "showdashboard": true,
     "dashboard": "Dashboard",
-    "uilayout": "terminal"
+    "uilayout": "terminal",
+    "ports": [
+      {
+        "port": 3000,
+        "on": "host01"
+      }
+    ]
   },
   "backend": {
     "imageid": "ubuntu"

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -55,18 +55,18 @@
   "environment": {
     "showdashboard": true,
     "dashboard": "Dashboard",
-    "uilayout": "terminal",
-    "ports": [
-      {
-        "port": 3000,
-        "on": "host01"
-      },
-            {
-        "port": 8013,
-        "on": "host01"
-      }
-    ]
+    "uilayout": "terminal"
   },
+  "ports": [
+    {
+      "port": 3000,
+      "on": "host01"
+    },
+          {
+      "port": 8013,
+      "on": "host01"
+    }
+  ],
   "backend": {
     "imageid": "ubuntu"
   }

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -47,7 +47,7 @@
       "host01": [
         { 
           "file": "assets/docker-compose.yaml",
-          "target": "/root/docker-compose.yaml"
+          "target": "/docker-compose.yaml"
         }
       ]
     }

--- a/flagd-demo/index.json
+++ b/flagd-demo/index.json
@@ -57,7 +57,7 @@
         },
         {
           "file": "docker-compose.yaml",
-          "target": "~"
+          "target": "/root/docker-compose.yaml"
         }
       ]
     }


### PR DESCRIPTION
## This PR

When trying to run the flagd demo it was failing. It was having issues with the `Gitea` setup successfully starting up, which caused the flagd starting to have an error because it couldn’t find the files.

- switched to using `Gitea` with a docker-compose that the script can spin up and is managed with docker and by `Gitea` instead of manually
- tea & flagd are still installed with the binary

### Related Issues

Fixes #33 

### Notes

- used as minimal dockerfile (as far as I can tell) that kind of mocks the killercoda env, wanted to make sure it would run in a container env and install where needed
- that dockerfile is within `flag-demo`

### Follow-up Tasks
- it needs to be tested for the killercoda env, not sure if they have like a preview link but that is the only part I couldn’t find in the creator doc.

### How to test

- to replicate how killercoda can run docker-compose, and properly assign host ports to the container like 3000:3000 this is how I found to run the dockerfile to get the steps to work locally
- in the killercoda env the {TRAFFIC_HOST1_3000:-} should be captured by the script and set as the BASE_URL

```
cd flagd-demo

docker buildx build -t killercoda-mock-test .
docker run -it --rm \
  -e BASE_URL=http://host.docker.internal \
  -v /var/run/docker.sock:/var/run/docker.sock \
  killercoda-mock-test
```

- after this the flagd start from step 2 can be ran 