### PR TITLE
fix: node install script for demo

### DIFF
--- a/five-minutes-to-feature-flags/assets/scripts/intro_foreground.sh
+++ b/five-minutes-to-feature-flags/assets/scripts/intro_foreground.sh
@@ -21,8 +21,9 @@ source ~/.bashrc
 # -----------------------------------
 # Installing Node
 # -----------------------------------
-curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - &&\
-apt install -y nodejs < /dev/null
+curl -fsSL https://deb.nodesource.com/setup_23.x | sudo -E bash - &&\
+apt-get install -y nodejs < /dev/null
+node -v
 
 
 # -----------------------------------
@@ -37,6 +38,7 @@ cd app
 #  npm install
 # -----------------------------------
 npm ci
+npm install -g npm@latest
 
 # ---------------------------------------------#
 #       🎉 Installation Complete 🎉           #


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- updates the node source script for installing node to get the demo working again

Before:
<img width="1472" alt="Screenshot 2025-06-13 at 7 53 19 PM" src="https://github.com/user-attachments/assets/882b6ca7-2277-4fce-89b8-01409f3fe825" />

After:

<img width="1472" alt="Screenshot 2025-06-13 at 7 59 51 PM" src="https://github.com/user-attachments/assets/a3d18bf4-99fb-405a-8ec1-6bf1fc8b155d" />


### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #35 

### How to test
<!-- if applicable, add testing instructions under this section -->

using my “test” environment that has these changes for the `Five Minutes to Feature Flags` demo. There you can see that the warning for the deprecated node script is gone, install happens, rest of steps happen and the demo can be successfully interacted with.

[the test demo](https://killercoda.com/openfeature-testing-demos/scenario/five-minutes-to-feature-flags)
